### PR TITLE
Changed function used for getting fullname of students

### DIFF
--- a/classes/notifstudents.php
+++ b/classes/notifstudents.php
@@ -93,7 +93,7 @@ class notifstudents
         $students = $this->get_users_from_course('student');
         if (!empty($students)) {
             foreach ($students as $id => $student) {
-                $listStudent[$id] = user_get_user_details($student)['fullname'];
+                $listStudent[$id] = fullname($student);
             }
         }
         return $listStudent;


### PR DESCRIPTION
Hi,

While testing this plugin on a clean install of Moodle, I noticed an issue. To replicate it, use the following steps:

- Create a new course
  - add one user with the role of `Teacher`
  - add one or more users with the role of `Student`
- Log in as the `Teacher`
- Add an activity to the course
- Turn on `Editing mode` and under `Edit` click the `Notifications` button on the added activity
- What should happen, is that the table under `Individual participants`, which should contain names of students, is actually empty

This happens because the `user_get_user_details` function, used in `classes/notifstudents.php` does some permission checking, which fails and the function returns NULL for each user instead of user details. The issue is not present when logged in as Admin.

I fixed the issue by changing the function to the `fullname` core Moodle function. If the `user_get_user_details` function needs to be used, the current course object can be passed to the function as the second argument - this changes the way the context is checked and also solves the issue.

Best regards,
Nejc