### PR TITLE
Moodle 4.x Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,13 @@ one to the resource, and the other to the course.
 The Moodle admin can modify this default setting.
 The teacher can change the text to send.
 
-The teacher can control who the message is sent to, by default all the users enrolled 
+The teacher can control who the message is sent to, by default all the users enrolled
 into the course and allowed to view the resource.
 The notification conforms to resource access restrictions such as course groups.
 
-
 ## Requirements
 
-* Moodle 3.0 is required
-
-Moodle has changed the way it loads plugins with its 3.1 version.
-The new API was introduced in Moodle 3.0, hence the requirements.
+* Moodle 4.0 is required
 
 Since 2018, the plugin package uses AMOS to translate the strings.
 You can help contribute new languages.
@@ -35,7 +31,6 @@ You can help contribute new languages.
 * Install the plugin into Moodle with either by typing `php admin/cli/upgrade.php` (CLI)
   or by visiting '/admin/index.php' (web).
 
-
 ## Credits
 
 This plugin was developped by [Silecs](http://www.silecs.info)
@@ -43,7 +38,8 @@ and initially sponsored by [Université Paris 1 Panthéon-Sorbonne, France](http
 
 Additional enhancements and migration to Moodle 3.x were sponsored by
 [Xi’an Jiaotong-Liverpool University (XJTLU)](http://www.xjtlu.edu.cn/en/academics/aec.html), China.
-Additional update to Moodle 3.2+ (Boost theme) has been sponsored by 
+Additional update to Moodle 3.2+ (Boost theme) has been sponsored by
 [Institut de Formation aux Métiers de la Santé](https://www.ch-valenciennes.fr/formation/ifms/)
 de Valenciennes, France.
 
+Moodle 4.x compatibility made by @Badatos

--- a/classes/notification.php
+++ b/classes/notification.php
@@ -180,7 +180,7 @@ class notification {
     /**
      * Envoie un message interne à l'utilisateur spécifié
      *
-     * @param stdClass $user
+     * @param \stdClass $user
      * @return mixed false ou resultat de la fonction message_send()
      **/
     private function send_message($user) {

--- a/classes/notification.php
+++ b/classes/notification.php
@@ -1,34 +1,62 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
- * @package    local_resourcenotif
- * @copyright  2012-2021 Silecs {@link http://www.silecs.info/societe}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * Resource Notifications
+ * @package   local_resourcenotif
+ * @copyright 2012-2021 Silecs {@link http://www.silecs.info/societe}
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 namespace local_resourcenotif;
 
-class notification
-{
-    /** @var stdClass $course course record */
-    public $course; //
-    /** @var stdClass $cm course_modules record */
-    public $cm; // course module
-    /** @var string $moduletype */
+/**
+ * notification class
+ */
+class notification {
+    /** @var \stdClass course record */
+    public $course;
+    /** @var \stdClass course_modules record */
+    public $cm;
+    /** @var string Module type */
     public $moduletype;
-
+    /** @var array message body info */
     private $msgbodyinfo;
+    /** @var int number of notifications sent */
     private $nbsent = 0;
-    private $message; //complete notification message
+    /** @var \stdClass complete notification message */
+    private $message;
 
-    public function __construct($course, $cm, $moduletype)
-    {
+    /**
+     * notification constructor.
+     * @param mixed $course
+     * @param mixed $cm
+     * @param mixed $moduletype
+     */
+    public function __construct($course, $cm, $moduletype) {
         $this->course = $course;
         $this->cm = $cm;
         $this->moduletype = $moduletype;
     }
 
-    public function set_message_body_info()
-    {
+    /**
+     * Set the message body info
+     * @return void
+     */
+    public function set_message_body_info() {
         global $USER;
         $site = \get_site();
 
@@ -44,8 +72,7 @@ class notification
     }
 
     /**
-     * build the $message attribute (subject, text body and html body)
-     *
+     * Build the $message attribute (subject, text body and html body)
      * @param string $complement
      * @return bool
      */
@@ -70,13 +97,12 @@ class notification
     }
 
     /**
-     * prepare the customdata to pass to the main form
+     * Prepare the customdata to pass to the main form
      * @param array $notifiablestudents
      * @return array
      */
-    public function get_form_customdata($notifiablestudents)
-    {
-        if ( ! $notifiablestudents ) {
+    public function get_form_customdata($notifiablestudents) {
+        if (!$notifiablestudents) {
             $recipients = get_string('norecipient', 'local_resourcenotif');
         } else {
             $recipients = $this->get_recipients_label(count($notifiablestudents));
@@ -119,7 +145,7 @@ class notification
     }
 
     /**
-     * Envoi une notification aux $users + copie à $USER
+     * Envoi une notification aux $users + copie à $USER.
      *
      * @param array $users
      * @return string interface message
@@ -173,7 +199,7 @@ class notification
         $eventdata->fullmessage = $this->message->bodytext;
         $eventdata->fullmessagehtml = $this->message->bodyhtml;
         // With FORMAT_HTML, most outputs will use fullmessagehtml, and convert it to plain text if necessary.
-        // but some output plugins will behave differently (airnotifier only uses fullmessage)
+        // but some output plugins will behave differently (airnotifier only uses fullmessage).
         $eventdata->fullmessageformat = FORMAT_HTML;
         // If smallmessage is not empty,
         // it will have priority over the 2 other fields, with a hard coded FORMAT_PLAIN.
@@ -189,10 +215,12 @@ class notification
      * @return string
      */
     private function get_message_subject() {
-        $subject = sprintf('%s %s - %s',
+        $subject = sprintf(
+            '%s %s - %s',
             get_string('notification', 'local_resourcenotif'),
             $this->course->shortname,
-            \format_string($this->cm->name));
+            \format_string($this->cm->name)
+        );
         return $subject;
     }
 
@@ -202,9 +230,9 @@ class notification
      * return string
      */
     public function get_message_body($type) {
-        $message_body = get_config('local_resourcenotif','message_body');
+        $messagebody = get_config('local_resourcenotif', 'message_body');
         $coursename = $this->msgbodyinfo['fullnamecourse'];
-        $message_body = str_replace('[[sender]]', $this->msgbodyinfo['user'], $message_body);
+        $messagebody = str_replace('[[sender]]', $this->msgbodyinfo['user'], $messagebody);
 
         if ($type == 'html') {
             $linkactivity = \html_writer::link($this->msgbodyinfo['urlactivity'], $this->msgbodyinfo['nameactivity']);
@@ -213,9 +241,8 @@ class notification
             $linkactivity = $this->msgbodyinfo['nameactivity'];
             $linkcourse = $coursename;
         }
-        $message_body = str_replace('[[linkactivity]]', $linkactivity, $message_body);
-        $message_body = str_replace('[[linkcourse]]', $linkcourse, $message_body);
-        return $message_body;
+        $messagebody = str_replace('[[linkactivity]]', $linkactivity, $messagebody);
+        $messagebody = str_replace('[[linkcourse]]', $linkcourse, $messagebody);
+        return $messagebody;
     }
-
 }

--- a/classes/notifstudents.php
+++ b/classes/notifstudents.php
@@ -1,38 +1,66 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
- * @package    local_resourcenotif
- * @copyright  2012-2021 Silecs {@link http://www.silecs.info/societe}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * Students notifications
+ * @package   local_resourcenotif
+ * @copyright 2012-2021 Silecs {@link http://www.silecs.info/societe}
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 namespace local_resourcenotif;
+
+defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot . '/user/lib.php');
 require_once($CFG->libdir . '/externallib.php');
 
-class notifstudents
-{
-
+/**
+ * Class notifstudents
+ */
+class notifstudents {
+    /**
+     * @var int Course id
+     */
     public $courseid;
+    /**
+     * @var \stdClass coursemodule description
+     */
     public $cm;
 
-    public function __construct($courseid, $cm)
-    {
+    /**
+     * notifstudents constructor.
+     * @param mixed $courseid
+     * @param mixed $cm
+     */
+    public function __construct($courseid, $cm) {
         $this->courseid = $courseid;
         $this->cm = $cm;
     }
 
     /**
-     * renvoie les utilisateurs ayant le rôle 'rolename'
-     * dans le cours $courseid
+     * Renvoie les utilisateurs ayant le rôle 'rolename'
+     * dans le cours courant
      *
-     * @param int $courseid
      * @param string $rolename shortname du rôle
      * @return array [users...]
      */
     public function get_users_from_course($rolename) {
         global $DB;
         $coursecontext = \context_course::instance($this->courseid);
-        $roletarget = $DB->get_record('role', ['shortname'=> $rolename]);
+        $roletarget = $DB->get_record('role', ['shortname' => $rolename]);
         $targetcontext = get_users_from_role_on_context($roletarget, $coursecontext);
 
         if (count($targetcontext) == 0) {
@@ -89,14 +117,14 @@ class notifstudents
      * @return array [id => student_fullname]
      **/
     public function get_list_students() {
-        $listStudent = [];
+        $liststudent = [];
         $students = $this->get_users_from_course('student');
         if (!empty($students)) {
             foreach ($students as $id => $student) {
-                $listStudent[$id] = user_get_user_details($student)['fullname'];
+                $liststudent[$id] = user_get_user_details($student)['fullname'];
             }
         }
-        return $listStudent;
+        return $liststudent;
     }
 
     /**

--- a/classes/resourcenotif_form.php
+++ b/classes/resourcenotif_form.php
@@ -41,6 +41,8 @@ class resourcenotif_form extends \moodleform {
         $mform = $this->_form;
         $customdata = $this->_customdata;
 
+        $selectattributes = ['size' => 5, 'class' => 'notif-selector'];
+
         // Hidden elements.
         $mform->addElement('hidden', 'id');
         $mform->setType('id', PARAM_INT);
@@ -61,8 +63,7 @@ class resourcenotif_form extends \moodleform {
             $optionssendall = ['disabled' => 'disabled'];
             $sendok = false;
         }
-        $mform->addElement('radio', 'send', '', '<span class="fake-fitemtitle">' .
-            $customdata['recipients'] . '</span>', 'all', $optionssendall);
+        $mform->addElement('radio', 'send', '', $customdata['recipients'], 'all', $optionssendall);
         if ($sendok) {
             $mform->setDefault('send', 'all');
         }
@@ -75,12 +76,24 @@ class resourcenotif_form extends \moodleform {
         $selected = [];
 
         if (count($allgroups)) {
-            $selectgroup = $mform->CreateElement('select', 'groups', 'Groupes', $allgroups);
+            $selectgroup = $mform->createElement(
+                'select',
+                'groups',
+                get_string('groups'),
+                $allgroups,
+                $selectattributes
+            );
             $selectgroup->setMultiple(true);
             $selected[] = $selectgroup;
         }
         if (count($allgroupings)) {
-            $selectgrouping = $mform->CreateElement('select', 'groupings', 'Groupements', $allgroupings);
+            $selectgrouping = $mform->createElement(
+                'select',
+                'groupings',
+                get_string('groupings', 'group'),
+                $allgroupings,
+                $selectattributes
+            );
             $selectgrouping->setMultiple(true);
             $selected[] = $selectgrouping;
         }
@@ -90,10 +103,10 @@ class resourcenotif_form extends \moodleform {
                 'radio',
                 'send',
                 '',
-                '<span class="fake-fitemtitle">' . get_string('selectedmembers', 'local_resourcenotif') . '</span>',
+                get_string('selectedmembers', 'local_resourcenotif'),
                 'selection'
             );
-            $mform->addGroup($selected, 'myselected', "", ['&nbsp;&nbsp;&nbsp;'], false);
+            $mform->addGroup($selected, 'myselected', "", [' '], false);
             $mform->disabledIf('groups[]', 'send', 'neq', 'selection');
             $mform->disabledIf('groupings[]', 'send', 'neq', 'selection');
             if ($sendok == false) {
@@ -101,16 +114,35 @@ class resourcenotif_form extends \moodleform {
                 $sendok = true;
             }
         } else {
-            $mform->addElement('radio', 'send', '', '<span class="fake-fitemtitle">'
-                . get_string('groupsgroupingsnone', 'local_resourcenotif') . '</span>', 'selection', ['disabled' => 'disabled']);
+            $mform->addElement(
+                'radio',
+                'send',
+                '',
+                get_string('groupsgroupingsnone', 'local_resourcenotif'),
+                'selection',
+                ['disabled' => 'disabled']
+            );
         }
 
         if (count($liststudents)) {
-            $mform->addElement('radio', 'send', '', '<span class="fake-fitemtitle">' .
-                get_string('selectstudents', 'local_resourcenotif') . '</span>', 'selectionstudents', $optionssendall);
-
-            $mform->addElement('select', 'students', '', $liststudents)->setMultiple(true);
-            $mform->disabledIf('students', 'send', 'neq', 'selectionstudents');
+            $mform->addElement(
+                'radio',
+                'send',
+                '',
+                get_string('specificstudents', 'local_resourcenotif'),
+                'selectionstudents',
+                $optionssendall
+            );
+            $selectstudent = $mform->createElement(
+                'select',
+                'students',
+                get_string('selectstudents', 'local_resourcenotif'),
+                $liststudents,
+                $selectattributes
+            );
+            $selectstudent->setMultiple(true);
+            $mform->addGroup([$selectstudent], '', '', ' ', false);
+            $mform->disabledIf('students[]', 'send', 'neq', 'selectionstudents');
         }
 
         // Message.
@@ -119,14 +151,17 @@ class resourcenotif_form extends \moodleform {
         $msgbody = $customdata['formmsgbody'];
         $msghtml = \html_writer::tag('p', $subjectlabel . $customdata['emailsubject'], ['class' => 'notificationlabel'])
             . \html_writer::tag('p', get_string('body', 'local_resourcenotif'), ['class' => 'notificationlabel notificationgras'])
-            . \html_writer::tag('p', $msgbody, ['class' => 'notificationlabel']);
+            . \html_writer::tag('blockquote', $msgbody, ['class' => 'notificationlabel']);
 
         $mform->addElement('html', $msghtml);
         $mform->setExpanded('message');
 
-        $mform->addElement('header', 'complementheader', get_string('complement', 'local_resourcenotif'));
-        $mform->setExpanded('complementheader');
-        $mform->addElement('textarea', 'complement', null, ['rows' => 5, 'class' => 'complement', 'style' => 'resize:both;']);
+        $mform->addElement(
+            'textarea',
+            'complement',
+            get_string('complement', 'local_resourcenotif'),
+            ['rows' => 5, 'class' => 'complement', 'style' => 'resize:both;']
+        );
         $mform->setType('complement', PARAM_RAW);
 
         // Buttons.

--- a/classes/resourcenotif_form.php
+++ b/classes/resourcenotif_form.php
@@ -1,22 +1,47 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
- * @package    local_resourcenotif
- * @copyright  2012-2021 Silecs {@link http://www.silecs.info/societe}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * Form for sending a notification
+ * @package   local_resourcenotif
+ * @copyright 2012-2021 Silecs {@link http://www.silecs.info/societe}
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 namespace local_resourcenotif;
 
-use \local_resourcenotif\notifstudents;
+use local_resourcenotif\notifstudents;
 
-require_once($CFG->libdir.'/formslib.php');
+defined('MOODLE_INTERNAL') || die();
 
+require_once($CFG->libdir . '/formslib.php');
+
+/**
+ * Form for sending a notification
+ */
 class resourcenotif_form extends \moodleform {
+    /**
+     * Form definition
+     * @return void
+     */
     public function definition() {
 
         $mform = $this->_form;
         $customdata = $this->_customdata;
 
-        // hidden elements
+        // Hidden elements.
         $mform->addElement('hidden', 'id');
         $mform->setType('id', PARAM_INT);
         $mform->addElement('hidden', 'mod');
@@ -24,16 +49,21 @@ class resourcenotif_form extends \moodleform {
         $mform->addElement('hidden', 'courseid');
         $mform->setType('courseid', PARAM_INT);
 
-        //recipients
+        // Recipients.
         $sendok = true;
-        $mform->addElement('header', 'recipient', get_string('recipients', 'local_resourcenotif'));
-        $optionsSendAll = [];
+        $mform->addElement(
+            'header',
+            'recipient',
+            get_string('recipients', 'local_resourcenotif')
+        );
+        $optionssendall = [];
         if ($customdata['nbNotifiedStudents'] == 0) {
-            $optionsSendAll = ['disabled' => 'disabled'];
+            $optionssendall = ['disabled' => 'disabled'];
             $sendok = false;
         }
-        $mform->addElement('radio', 'send', '', '<span class="fake-fitemtitle">' . $customdata['recipients'] . '</span>', 'all', $optionsSendAll);
-        if($sendok) {
+        $mform->addElement('radio', 'send', '', '<span class="fake-fitemtitle">' .
+            $customdata['recipients'] . '</span>', 'all', $optionssendall);
+        if ($sendok) {
             $mform->setDefault('send', 'all');
         }
 
@@ -45,12 +75,12 @@ class resourcenotif_form extends \moodleform {
         $selected = [];
 
         if (count($allgroups)) {
-            $selectgroup = $mform->CreateElement('select','groups', 'Groupes', $allgroups);
+            $selectgroup = $mform->CreateElement('select', 'groups', 'Groupes', $allgroups);
             $selectgroup->setMultiple(true);
             $selected[] = $selectgroup;
         }
         if (count($allgroupings)) {
-            $selectgrouping = $mform->CreateElement('select','groupings', 'Groupements', $allgroupings);
+            $selectgrouping = $mform->CreateElement('select', 'groupings', 'Groupements', $allgroupings);
             $selectgrouping->setMultiple(true);
             $selected[] = $selectgrouping;
         }
@@ -77,13 +107,13 @@ class resourcenotif_form extends \moodleform {
 
         if (count($liststudents)) {
             $mform->addElement('radio', 'send', '', '<span class="fake-fitemtitle">' .
-                get_string('selectstudents', 'local_resourcenotif') . '</span>', 'selectionstudents', $optionsSendAll);
+                get_string('selectstudents', 'local_resourcenotif') . '</span>', 'selectionstudents', $optionssendall);
 
             $mform->addElement('select', 'students', '', $liststudents)->setMultiple(true);
             $mform->disabledIf('students', 'send', 'neq', 'selectionstudents');
         }
 
-        //message
+        // Message.
         $mform->addElement('header', 'message', get_string('content', 'local_resourcenotif'));
         $subjectlabel = \html_writer::tag('span', get_string('subject', 'local_resourcenotif'), ['class' => 'notificationgras']);
         $msgbody = $customdata['formmsgbody'];
@@ -94,18 +124,22 @@ class resourcenotif_form extends \moodleform {
         $mform->addElement('html', $msghtml);
         $mform->setExpanded('message');
 
-        $mform->addElement('header', 'complementheader', get_string('complement', 'local_resourcenotif') );
+        $mform->addElement('header', 'complementheader', get_string('complement', 'local_resourcenotif'));
         $mform->setExpanded('complementheader');
         $mform->addElement('textarea', 'complement', null, ['rows' => 5, 'class' => 'complement', 'style' => 'resize:both;']);
         $mform->setType('complement', PARAM_RAW);
 
-        //-------------------------------------------------------------------------------
-        // buttons
+        // Buttons.
         if ($sendok) {
-            $this->add_action_buttons(true,  get_string('submit', 'local_resourcenotif'));
+            $this->add_action_buttons(true, get_string('submit', 'local_resourcenotif'));
         }
     }
 
+    /**
+     * Form validation
+     * @param mixed $data
+     * @param mixed $files
+     */
     public function validation($data, $files) {
         $errors = parent::validation($data, $files);
         if (empty($errors)) {
@@ -114,6 +148,11 @@ class resourcenotif_form extends \moodleform {
         return $errors;
     }
 
+    /**
+     * Validate the recipient
+     * @param mixed $data
+     * @param mixed $errors
+     */
     private function validation_recipient($data, &$errors) {
         if (isset($data['send'])) {
             if ($data['send'] == 'selection' && !isset($data['groups']) && !isset($data['groupings'])) {

--- a/db/messages.php
+++ b/db/messages.php
@@ -1,16 +1,32 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
- * @package    local_resourcenotif
- * @copyright  2012-2021 Silecs {@link http://www.silecs.info/societe}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * Message providers
+ * @package   local_resourcenotif
+ * @copyright 2012-2021 Silecs {@link http://www.silecs.info/societe}
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$messageproviders = array (
-    'resourcenotif_notification' => array(
-        'defaults' => array(
-            'email' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF
-        ),
-    ),
-);
+defined('MOODLE_INTERNAL') || die();
 
-
+$messageproviders = [
+    'resourcenotif_notification' => [
+        'defaults' => [
+            'email' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
+        ],
+    ],
+];

--- a/lang/en/local_resourcenotif.php
+++ b/lang/en/local_resourcenotif.php
@@ -1,24 +1,42 @@
 <?php
-/**
- * @package    local_resourcenotif
- * @copyright  2012-2021 Silecs {@link http://www.silecs.info/societe}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-$string['pluginname'] = 'Resource notification';
+/**
+ * Strings for component 'resourcenotif', language 'en'
+ * @package   local_resourcenotif
+ * @copyright 2012-2021 Silecs {@link http://www.silecs.info/societe}
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 
 $string['allstudentrecipient'] = 'Students enrolled in this course ({$a}).';
 $string['body'] = 'Message body: ';
 $string['complement'] = 'Additional comments (optional): ';
 $string['content'] = 'Content';
+$string['descriptionmsg'] = 'Available parameters: [[sender]], [[linkactivity]], [[linkcourse]]';
 $string['errorselectgroup'] = 'You must select at least one group/grouping';
 $string['errorselectrecipient'] = 'Please select a recipient';
 $string['errorselectstudent'] = 'You must select at least one participant';
-$string['groupsgroupingsnone'] = 'No groups/groupings';
 $string['grouprecipient'] = 'Participants allowed to view <a href="{$a->linkactivity}">{$a->nameactivity}</a> ({$a->nbdest} users - Restrict access conditions have been applied to this activity/resource)';
+$string['groupsgroupingsnone'] = 'No groups/groupings';
+$string['messageprovider:resourcenotif_notification'] = 'Activity/resource notifications';
 $string['nomessagesend'] = 'No sent message.';
 $string['norecipient'] = 'No recipient.';
+$string['notification'] = 'Notification: ';
 $string['numbernotification'] = 'Number of notifications sent: {$a}';
+$string['pluginname'] = 'Resource notification';
 $string['recipients'] = 'Recipients';
 $string['returncourse'] = 'Return to course';
 $string['selectedmembers'] = 'Members of selected groups/groupings: ';
@@ -27,10 +45,3 @@ $string['sender'] = 'Sender: ';
 $string['sendnotification'] = 'Send a notification';
 $string['subject'] = 'Subject: ';
 $string['submit'] = 'Send';
-
-//admin setting
-$string['descriptionmsg'] = 'Available parameters: [[sender]], [[linkactivity]], [[linkcourse]]';
-$string['notification'] = 'Notification: ';
-
-//Default message outputs
-$string['messageprovider:resourcenotif_notification'] = 'Activity/resource notifications';

--- a/lang/en/local_resourcenotif.php
+++ b/lang/en/local_resourcenotif.php
@@ -43,5 +43,6 @@ $string['selectedmembers'] = 'Members of selected groups/groupings: ';
 $string['selectstudents'] = 'Individual participants';
 $string['sender'] = 'Sender: ';
 $string['sendnotification'] = 'Send a notification';
+$string['specificstudents'] = 'Specific participants';
 $string['subject'] = 'Subject: ';
 $string['submit'] = 'Send';

--- a/lib.php
+++ b/lib.php
@@ -1,22 +1,47 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
- * @package    local_resourcenotif
- * @copyright  2012-2021 Silecs {@link http://www.silecs.info/societe}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * Resource Notification library
+ * @package   local_resourcenotif
+ * @copyright 2012-2021 Silecs {@link http://www.silecs.info/societe}
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+/**
+ * Summary of local_resourcenotif_extend_navigation_course
+ * @return void
+ */
 function local_resourcenotif_extend_navigation_course() {
     global $OUTPUT, $PAGE;
 
-    $linkItem = '<a class="dropdown-item editing_notifications menu-action cm-edit-action" data-action="notifications" role="menuitem" href="'
-        . htmlspecialchars(new moodle_url('/local/resourcenotif/resourcenotif.php', array('id' => '123XYZ321')))
-        . '" title="' . htmlspecialchars(get_string("notifications")) . '">'
+    $linkitem = '<a class="dropdown-item editing_notifications menu-action cm-edit-action"'
+        . 'data-action="notifications" role="menuitem" href="'
+        . htmlspecialchars(
+            new moodle_url(
+                '/local/resourcenotif/resourcenotif.php',
+                ['id' => '123XYZ321']
+            )
+        ) . '" title="' . htmlspecialchars(get_string("notifications")) . '">'
         . $OUTPUT->pix_icon('t/email', get_string("notifications"))
         . '<span class="menu-action-text">' . htmlspecialchars(get_string("notifications")) . '</span>'
         . '</a>';
 
-    //style Boost
-    $enc = json_encode($linkItem);
+    // Style Boost.
+    $enc = json_encode($linkitem);
     $PAGE->requires->js_init_code(<<<EOJS
     var activities = document.querySelectorAll('.section-cm-edit-actions div[role="menu"]');
     if (activities) {
@@ -32,8 +57,8 @@ function local_resourcenotif_extend_navigation_course() {
 EOJS
     , true);
 
-    //code style Clean
-    $enc = json_encode('<li role="presentation">' . $linkItem . '</li>');
+    // Code style Clean.
+    $enc = json_encode('<li role="presentation">' . $linkitem . '</li>');
     $PAGE->requires->js_init_code(<<<EOJS
     var activities = document.querySelectorAll('.section-cm-edit-actions ul[role="menu"]');
     if (activities) {
@@ -49,4 +74,3 @@ EOJS
 EOJS
     , true);
 }
-

--- a/resourcenotif.css
+++ b/resourcenotif.css
@@ -4,23 +4,31 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 .cache {
-	display: none;
+  display: none;
 }
+
+/*
 .notificationlabel {
-    /**margin-left:16%;**/
+  margin-left:16%;
 }
+*/
+
 .notificationgras {
-    font-weight: 700;
+  font-weight: 700;
 }
+
 #id_submitbutton {
-    font-weight: 700;
+  font-weight: 700;
 }
+
 #fitem_id_complement div.fitemtitle {
-    width: 0px;
+  width: 0;
 }
+
 #fitem_id_complement div.felement {
-    margin: 0px;
+  margin: 0;
 }
+
 .complement {
-    width: 100%;
+  width: 100%;
 }

--- a/resourcenotif.css
+++ b/resourcenotif.css
@@ -13,12 +13,12 @@
 }
 */
 
-.notificationgras {
+.notificationgras, #id_submitbutton {
   font-weight: 700;
 }
 
-#id_submitbutton {
-  font-weight: 700;
+span.notificationgras {
+  margin-right: .5em;
 }
 
 #fitem_id_complement div.fitemtitle {
@@ -31,4 +31,8 @@
 
 .complement {
   width: 100%;
+}
+
+.mform .d-flex .notif-selector {
+  margin-left: 1.5em !important;
 }

--- a/resourcenotif.php
+++ b/resourcenotif.php
@@ -1,31 +1,47 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
- * @package    local_resourcenotif
- * @copyright  2012-2021 Silecs {@link http://www.silecs.info/societe}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * Resource Notification main page
+ * @package   local_resourcenotif
+ * @copyright 2012-2021 Silecs {@link http://www.silecs.info/societe}
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-use \local_resourcenotif\notification;
-use \local_resourcenotif\notifstudents;
-use \local_resourcenotif\resourcenotif_form;
+use local_resourcenotif\notification;
+use local_resourcenotif\notifstudents;
+use local_resourcenotif\resourcenotif_form;
 
 require_once("../../config.php");
 
 $id = required_param('id', PARAM_INT);
 
 if (! $cm = get_coursemodule_from_id('', $id)) {
-    print_error('invalidcoursemodule');
+    throw new \moodle_exception('invalidcoursemodule');
 }
 
 if (! $moduletype = $DB->get_field('modules', 'name', ['id' => $cm->module], MUST_EXIST)) {
-    print_error('invalidmodule');
+    throw new \moodle_exception('invalidmodule');
 }
 
 if (! $course = $DB->get_record('course', ['id' => $cm->course])) {
-    print_error('coursemisconf');
+    throw new \moodle_exception('coursemisconf');
 }
 
 if (! $module = $DB->get_record($moduletype, ['id' => $cm->instance])) {
-    print_error('invalidcoursemodule');
+    throw new \moodle_exception('invalidcoursemodule');
 }
 
 require_login($course, false, $cm);
@@ -72,25 +88,25 @@ if ($formdata) {
         case 'selection':
             $groups = [];
             if (isset($formdata->groups) && count($formdata->groups)) {
-               $groups =  $formdata->groups;
+                $groups = $formdata->groups;
             }
             $groupings = [];
             if (isset($formdata->groupings) && count($formdata->groupings)) {
-               $groupings =  $formdata->groupings;
+                $groupings = $formdata->groupings;
             }
-            $grpNotifiedStudents = notifstudents::get_users_recipients($groups, $groupings);
-            if (count($grpNotifiedStudents)) {
-                $msgresult = $notificationprocess->send_notifications($grpNotifiedStudents);
+            $grpnotifiedstudents = notifstudents::get_users_recipients($groups, $groupings);
+            if (count($grpnotifiedstudents)) {
+                $msgresult = $notificationprocess->send_notifications($grpnotifiedstudents);
             }
             break;
         case 'selectionstudents':
             $listidstudents = $formdata->students;
             if (count($listidstudents)) {
-                $notifiedS = [];
+                $notifieds = [];
                 foreach ($listidstudents as $id) {
-                    $notifiedS[$id] = $notifiablestudents[$id];
+                    $notifieds[$id] = $notifiablestudents[$id];
                 }
-                $msgresult = $notificationprocess->send_notifications($notifiedS);
+                $msgresult = $notificationprocess->send_notifications($notifieds);
             }
             break;
     }

--- a/settings.php
+++ b/settings.php
@@ -1,11 +1,25 @@
 <?php
-/**
- * @package    local_resourcenotif
- * @copyright  2012-2021 Silecs {@link http://www.silecs.info/societe}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/* @var $ADMIN admin_root */
+/**
+ * Resource Notification admin settings and defaults
+ * @package   local_resourcenotif
+ * @copyright 2012-2021 Silecs {@link http://www.silecs.info/societe}
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 
 defined('MOODLE_INTERNAL') || die;
 
@@ -16,10 +30,12 @@ if (has_capability('moodle/site:config', context_system::instance())) {
     $defaultmsg = '[[sender]] would like to draw your attention to the activity/resource '
         . '[[linkactivity]] available within the course [[linkcourse]].';
     $description = get_string('descriptionmsg', 'local_resourcenotif');
-    $message = new admin_setting_configtextarea('message_body',
+    $message = new admin_setting_configtextarea(
+        'message_body',
         get_string('body', 'local_resourcenotif'),
         $description,
-        $defaultmsg);
+        $defaultmsg
+    );
     $message->plugin = 'local_resourcenotif';
     $settings->add($message);
 }

--- a/version.php
+++ b/version.php
@@ -1,16 +1,34 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
- * @package    local_resourcenotif
- * @copyright  2012-2021 Silecs {@link http://www.silecs.info/societe}
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * Resource Notification version information
+ * @package   local_resourcenotif
+ * @copyright 2012-2021 Silecs {@link http://www.silecs.info/societe}
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021032002;
-$plugin->release   = "3.2.2";
-$plugin->requires  = 2015111600; // 3.0
+$plugin->version   = 2025022600;
+$plugin->release   = "3.3.0";
+$plugin->requires  = 2023100900; // 4.3
 $plugin->component = 'local_resourcenotif';
 
-$plugin->maturity = MATURITY_STABLE;
+// Moodle versions that are outside of this range will produce a message notifying at install time, but will allow for installation.
+$plugin->supported = [403, 405];     // Moodle 4.3.x to 4.5.x are supported.
 
+$plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Hello !
This PR is here to resolve the #21 issue, and improve the plugin compatibility with Moodle 4.x

* [x] Replace deprecated `print_error` by `throw new \moodle_exception`
* [x] Replace deprecated `MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF` by `MESSAGE_DEFAULT_ENABLED`

It also use the new Moodle Code styling rules, to reduce php Code checker & PHPdoc errors & warnings